### PR TITLE
Refactor to have endpoint specific auth exclusions

### DIFF
--- a/src/app/api/controllers/auth.py
+++ b/src/app/api/controllers/auth.py
@@ -18,7 +18,7 @@ class AuthController(Controller):
     dependencies = {"users_repo": Provide(provide_users_repo)}
     tags = ["auth"]
 
-    @post("/login")
+    @post("/login", exclude_from_auth=True)
     async def login(
         self, users_repo: UserRepository, data: LoginRequest
     ) -> Response[TokenResponse]:

--- a/src/app/api/controllers/file.py
+++ b/src/app/api/controllers/file.py
@@ -194,7 +194,7 @@ class FileController(Controller):
             file_id=str(file_model.id),  # Return file ID for webhook
         )
 
-    @post("/webhook/s3-upload")
+    @post("/webhook/s3-upload", exclude_from_auth=True)
     async def s3_upload_webhook(
         self,
         files_repo: FileRepository,

--- a/src/app/auth/jwt.py
+++ b/src/app/auth/jwt.py
@@ -25,7 +25,7 @@ jwt_auth = JWTAuth[AuthUser](
     default_token_expiration=timedelta(
         minutes=settings.jwt.access_token_expire_minutes
     ),
-    exclude=["/health", "/schema", "/auth.*"],
+    exclude=["/schema"],
     auth_header="Authorization",
 )
 


### PR DESCRIPTION
Refactor to have endpoint specific auth exclusions
- Add exclude_from_auth=True to S3 webhook endpoint for AWS access
- Add exclude_from_auth=True to auth/login endpoint for public access
- Simplify global JWT exclude list to only include /schema
- Use handler-level auth exclusions instead of global patterns for better security and clarity

This approach provides more granular control over authentication requirements per endpoint.